### PR TITLE
ROC-3501: Use options simple to decide rejections

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ function Request(url, options, f, retryConfig) {
       return this._reject(err);
     }
 
-    if (isErrorResponse(response)) {
+    if (options.simple && isErrorResponse(response)) {
       return this._reject(new StatusCodeError(response.statusCode, body, this.options, response));
     }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hmcts/requestretry",
   "description": "request-retry wrap nodejs request to retry http(s) requests in case of error",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "Francois-Guillaume Ribreau",
     "email": "npm@fgribreau.com",


### PR DESCRIPTION
We were not utilising the `options.simple` passed and were rejecting all non 2xx status codes, which was causing issues in postcode lookup. This PR uses the passed `options.simple` to decide rejections. 